### PR TITLE
Some debug and added simple tests for GPS. GPS thread leads to involu…

### DIFF
--- a/bgeigie_firmware/TinyGPS.cpp
+++ b/bgeigie_firmware/TinyGPS.cpp
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // Needed for millis
 #include <Arduino.h>
+#undef max
+#undef min
 
 #include <cmath>
 
@@ -31,6 +33,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define TWO_PI 6.283185307179586
 
+/*
 float radians(float deg)
 {
   //return deg * TWO_PI / 360;
@@ -41,6 +44,7 @@ float degrees(float rad)
   //return rad * 360. / TWO_PI;
   return rad * 57.29577;
 }
+*/
 
 #define _GPRMC_TERM   "GPRMC"
 #define _GPGGA_TERM   "GPGGA"

--- a/bgeigie_firmware/aggregator.cpp
+++ b/bgeigie_firmware/aggregator.cpp
@@ -3,5 +3,9 @@
 
 void Aggregator::update()
 {
+  if (_gps->available())
+  {
+    bool got_data = _gps->get_data(_current_data.gps);
+  }
 
 }

--- a/bgeigie_firmware/aggregator.hpp
+++ b/bgeigie_firmware/aggregator.hpp
@@ -6,8 +6,6 @@
 #include "patterns.hpp"
 #include "measurements.hpp"
 
-using std::forward_list;
-
 struct DataStamp
 {
   GPSData gps;
@@ -21,9 +19,12 @@ class Aggregator : public Observer
   private:
     DataStamp _current_data;
 
+    // The data producers
+    GPSThread *_gps;
+
   public:
-    Aggregator();
-    virtual ~Aggregator();
+    Aggregator(GPSThread *gps) : _gps(gps) {}
+    virtual ~Aggregator() {}
 
     // method to be called by subjects
     void update();

--- a/bgeigie_firmware/threaded_gps.cpp
+++ b/bgeigie_firmware/threaded_gps.cpp
@@ -120,12 +120,12 @@ void *GPSThread::update_loop(void* param)
   // Start never ending loop
   for(;;) {
 
-    while (Serial1.available())
+    while (gps_thread->serial_in().available())
     {
       if (gps_thread->available())
         gps_thread->unset_avalaible();
 
-      char c = Serial1.read();
+      char c = gps_thread->serial_in().read();
 
       if (c == '\n')  // update the info at then end of each line
       {

--- a/bgeigie_firmware/threaded_gps.hpp
+++ b/bgeigie_firmware/threaded_gps.hpp
@@ -67,6 +67,8 @@ class GPSThread : public Measurement<GPSData>
     // Implementation of Measurement API
     void init();
     bool prepare_data(GPSData &dest);
+
+    SerialSource &serial_in() { return *_serial_input; }
 };
 
 #endif

--- a/test/test_gps_raw/test_gps_raw.ino
+++ b/test/test_gps_raw/test_gps_raw.ino
@@ -1,0 +1,21 @@
+#include <M5Stack.h>
+
+HardwareSerial GPSRaw(2);
+
+void setup() {
+
+  M5.begin();
+  GPSRaw.begin(9600);
+
+  Serial.begin(115200);
+  Serial.println("hello");
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+  if(GPSRaw.available()) {
+    char ch = GPSRaw.read();
+    Serial.print(ch);
+  }
+}

--- a/test/test_gpsthreaded/TinyGPS.cpp
+++ b/test/test_gpsthreaded/TinyGPS.cpp
@@ -1,0 +1,1 @@
+../../bgeigie_firmware/TinyGPS.cpp

--- a/test/test_gpsthreaded/TinyGPS.h
+++ b/test/test_gpsthreaded/TinyGPS.h
@@ -1,0 +1,1 @@
+../../bgeigie_firmware/TinyGPS.h

--- a/test/test_gpsthreaded/measurements.hpp
+++ b/test/test_gpsthreaded/measurements.hpp
@@ -1,0 +1,1 @@
+../../bgeigie_firmware/measurements.hpp

--- a/test/test_gpsthreaded/patterns.hpp
+++ b/test/test_gpsthreaded/patterns.hpp
@@ -1,0 +1,1 @@
+../../bgeigie_firmware/patterns.hpp

--- a/test/test_gpsthreaded/serial_source.hpp
+++ b/test/test_gpsthreaded/serial_source.hpp
@@ -1,0 +1,1 @@
+../../bgeigie_firmware/serial_source.hpp

--- a/test/test_gpsthreaded/test_gpsthreaded.ino
+++ b/test/test_gpsthreaded/test_gpsthreaded.ino
@@ -1,0 +1,58 @@
+
+// Get around problem due to Arduino.h redefining min/max
+// https://stackoverflow.com/questions/41093090/esp8266-error-macro-min-passed-3-arguments-but-takes-just-2<Paste>
+
+#include <M5Stack.h>
+#undef max
+#undef min
+
+#include "serial_source.hpp"
+#include "threaded_gps.hpp"
+
+struct GPSSerialIn : public SerialSource
+{
+  HardwareSerial *hs;
+  GPSSerialIn(HardwareSerial *_hs) : hs(_hs) { }
+  bool available() { return hs->available(); }
+  char read() { return hs->read(); }
+};
+
+struct GPSSerialOut : public SerialSink
+{
+  HardwareSerial *hs;
+  GPSSerialOut(HardwareSerial *_hs) : hs(_hs) { }
+  size_t println(char *buf) { return hs->println(buf); };
+  size_t write(char *buf) { return hs->write(buf); };
+};
+
+GPSSerialIn gps_serial_in(&Serial2);
+GPSSerialOut gps_serial_out(&Serial);
+
+// Receptacle for the GPS data
+GPSThread gps_thread(&gps_serial_in, &gps_serial_out);
+GPSData gps_data;
+
+void setup() {
+
+  //M5.begin();
+
+  Serial.begin(115200);  // terminal
+
+  // Starting the GPS
+  Serial2.begin(9600);
+  gps_thread.init();
+
+  Serial.println("hello");
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+  // Wait for new GPS data
+  while (!gps_thread.prepare_data(gps_data))
+    ;
+  
+  Serial.println(gps_data.nbsat);
+  delay(1000);
+  
+}

--- a/test/test_gpsthreaded/threaded_gps.cpp
+++ b/test/test_gpsthreaded/threaded_gps.cpp
@@ -1,0 +1,1 @@
+../../bgeigie_firmware/threaded_gps.cpp

--- a/test/test_gpsthreaded/threaded_gps.hpp
+++ b/test/test_gpsthreaded/threaded_gps.hpp
@@ -1,0 +1,1 @@
+../../bgeigie_firmware/threaded_gps.hpp


### PR DESCRIPTION
I added two tests for GPS:

* Raw GPS readings redirected to Serial
* Threaded GPS reader with the Measurement/Data API that we designed with @Claypuppet .

At this point, the threaded GPS causes the M5Stack board to reboot every 5 seconds or so. Haven't figured out why yet.